### PR TITLE
feat: sync payment deletion across admin, caretaker, and tenant sides

### DIFF
--- a/backend/controllers/admin/adminPaymentController.js
+++ b/backend/controllers/admin/adminPaymentController.js
@@ -130,8 +130,24 @@ export const updatePaymentAdmin = async (req, res) => {
 export const deletePaymentAdmin = async (req, res) => {
   try {
     const adminId = req.admin?.id || req.auth?.id;
-    await deletePayment(req.params.id, adminId);
+    const result = await deletePayment(req.params.id, adminId);
+
+    // Broadcast to all listeners (admin/caretaker list refresh)
     emitEvent(req, "payment_updated");
+
+    // Push real-time update directly to the affected tenant
+    const io = req.app.get("io");
+    if (result?.tenantId) {
+      io.to(`user_${result.tenantId}`).emit("payment_updated");
+      io.to(`user_${result.tenantId}`).emit("new_notification", {
+        title: "Bill Removed",
+        message: "One of your unpaid bills has been removed by the admin.",
+        type: "payment",
+        is_read: false,
+        created_at: new Date().toISOString(),
+      });
+    }
+
     return res.status(200).json({ success: true, message: "Payment deleted" });
   } catch (error) {
     return res.status(400).json({ success: false, message: error.message });

--- a/backend/models/payment.js
+++ b/backend/models/payment.js
@@ -61,6 +61,15 @@ const Payment = sequelize.define(
       allowNull: false,
       defaultValue: "Unpaid",
     },
+    is_deleted: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    deleted_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
   },
   {
     tableName: "payments",
@@ -71,6 +80,7 @@ const Payment = sequelize.define(
       { fields: ["contract_id"] },
       { fields: ["status"] },
       { fields: ["billing_month"] },
+      { fields: ["is_deleted"] },
     ],
   }
 );

--- a/backend/routes/admin/adminPaymentRoutes.js
+++ b/backend/routes/admin/adminPaymentRoutes.js
@@ -1,4 +1,5 @@
 import express from "express";
+import { Op } from "sequelize";
 import adminAuth from "../../middleware/adminAuth.js";
 import uploadUtilityBill from "../../middleware/uploadUtilityBill.js";
 import Payment from "../../models/payment.js";
@@ -21,7 +22,7 @@ const checkDuplicatePayment = async (req, res, next) => {
     const { contract_id, category, billing_month } = req.body;
     if (!contract_id || !category || !billing_month) return next();
 
-    const existing = await Payment.findOne({ where: { contract_id, category, billing_month } });
+    const existing = await Payment.findOne({ where: { contract_id, category, billing_month, is_deleted: { [Op.or]: [false, null] } } });
     if (existing) {
       return res.status(400).json({ success: false, message: "Payment for this month already exists." });
     }

--- a/backend/server.js
+++ b/backend/server.js
@@ -172,8 +172,13 @@ const PORT = process.env.PORT || 5000;
 httpServer.listen(PORT, async () => {
   try {
     await connectDB();
-    await sequelize.sync({ alter: false });
-    console.log("Database synchronized successfully");
+
+    try {
+      await sequelize.sync({ alter: false });
+      console.log("Database synchronized successfully");
+    } catch (syncError) {
+      console.warn("Database sync warning (non-fatal):", syncError.message);
+    }
 
     await runSeeders();
     startSystemCron();

--- a/backend/services/admin/adminPaymentService.js
+++ b/backend/services/admin/adminPaymentService.js
@@ -27,7 +27,8 @@ export const createPayment = async ({ contract_id, category, billing_month, amou
   const today = new Date().setHours(0, 0, 0, 0);
   if (new Date(due_date).setHours(0, 0, 0, 0) < today) throw new Error("Due date cannot be in the past.");
 
-  const existing = await Payment.findOne({ where: { contract_id, category, billing_month } });
+  // Only check non-deleted records for duplicates
+  const existing = await Payment.findOne({ where: { contract_id, category, billing_month, is_deleted: { [Op.or]: [false, null] } } });
   if (existing) throw new Error("Payment for this month already exists.");
 
   const payment = await Payment.create({
@@ -64,15 +65,17 @@ export const createPayment = async ({ contract_id, category, billing_month, amou
 };
 
 export const getAllPayments = async () => {
-  // Eagerly mark any unpaid payments past their due date as Overdue before returning
   const now = new Date();
   const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+
+  // Mark overdue — exclude hard-deleted and soft-deleted rows
   await Payment.update(
     { status: "Overdue" },
-    { where: { due_date: { [Op.lt]: todayStr }, status: "Unpaid" } }
+    { where: { due_date: { [Op.lt]: todayStr }, status: "Unpaid", is_deleted: { [Op.or]: [false, null] } } }
   );
 
   return await Payment.findAll({
+    where: { is_deleted: { [Op.or]: [false, null] } },
     include: [{
       model: Contract,
       as: "contract",
@@ -87,8 +90,7 @@ export const getAllPayments = async () => {
         },
       ],
     }],
-  
-    order: [["billing_month", "DESC"]], 
+    order: [["billing_month", "DESC"]],
   });
 };
 
@@ -174,20 +176,33 @@ export const getMonthlySummary = async (billingMonth) => {
 };
 
 export const getPaymentDashboard = async () => {
-  // Sync overdue status before computing dashboard counts
+  // Sync overdue status before computing dashboard counts (skip soft-deleted bills)
   const now = new Date();
   const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
   await Payment.update(
     { status: "Overdue" },
-    { where: { due_date: { [Op.lt]: todayStr }, status: "Unpaid" } }
+    { where: { due_date: { [Op.lt]: todayStr }, status: "Unpaid", is_deleted: { [Op.or]: [false, null] } } }
   );
 
-  const totalCollected = (await Payment.sum("amount", { where: { status: "Paid" } })) || 0;
-  const pendingVerification = await Payment.count({ where: { status: "Pending Verification" } });
-  const overduePayments = await Payment.count({ where: { status: "Overdue" } });
+  const totalCollected = (await Payment.sum("amount", { where: { status: "Paid", is_deleted: { [Op.or]: [false, null] } } })) || 0;
+  const pendingVerification = await Payment.count({ where: { status: "Pending Verification", is_deleted: { [Op.or]: [false, null] } } });
+  const overduePayments = await Payment.count({ where: { status: "Overdue", is_deleted: { [Op.or]: [false, null] } } });
+
+  // Current billing month (YYYY-MM-01)
+  const currentMonthStart = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-01`;
+  const currentMonthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+  const currentMonthEndStr = `${currentMonthEnd.getFullYear()}-${String(currentMonthEnd.getMonth() + 1).padStart(2, "0")}-${String(currentMonthEnd.getDate()).padStart(2, "0")}`;
+
+  const totalMonthlyCollected = (await Payment.sum("amount", {
+    where: {
+      status: "Paid",
+      is_deleted: { [Op.or]: [false, null] },
+      billing_month: { [Op.between]: [currentMonthStart, currentMonthEndStr] },
+    },
+  })) || 0;
 
   const unpaidRecords = await Payment.findAll({
-    where: { status: "Unpaid" },
+    where: { status: "Unpaid", is_deleted: { [Op.or]: [false, null] } },
     attributes: ["ID"],
     include: [{
       model: Contract,
@@ -213,7 +228,7 @@ export const getPaymentDashboard = async () => {
     raw: true,
   });
 
-  return { totalCollected, pendingVerification, overduePayments, unpaidBills, unpaidUnitNumbers, monthlyRevenue };
+  return { totalCollected, totalMonthlyCollected, currentBillingMonth: currentMonthStart, pendingVerification, overduePayments, unpaidBills, unpaidUnitNumbers, monthlyRevenue };
 };
 
 export const updatePayment = async (paymentId, data, adminId) => {
@@ -249,13 +264,40 @@ export const updatePayment = async (paymentId, data, adminId) => {
 
 export const deletePayment = async (paymentId, adminId) => {
   const payment = await Payment.findByPk(paymentId, {
-    include: [{ model: Contract, as: "contract", include: [{ model: Unit, as: "unit", attributes: ["unit_number"] }] }],
+    include: [{
+      model: Contract,
+      as: "contract",
+      include: [
+        { model: Unit, as: "unit", attributes: ["unit_number"] },
+        { model: User, as: "tenants", attributes: ["ID", "contactNumber"], through: { attributes: [] } },
+      ],
+    }],
   });
   if (!payment) throw new Error("Payment not found");
 
+  // Only unpaid bills (Unpaid / Overdue) can be deleted
+  if (payment.status === "Paid") throw new Error("Paid bills cannot be deleted.");
+  if (payment.status === "Pending Verification") throw new Error("Bills pending verification cannot be deleted. Reject the receipt first.");
+
   const unitNumber = payment.contract?.unit?.unit_number ?? "—";
   const category = payment.category;
+  const tenant = payment.contract?.tenants?.[0];
+
+  // Hard delete — removes the row entirely so the same bill can be re-created
   await payment.destroy();
+
+  // Notify the tenant in-app
+  if (tenant?.ID) {
+    await createNotification({
+      userId: tenant.ID,
+      role: "tenant",
+      type: "bill deleted",
+      title: "Bill Removed",
+      message: `Your ${category} bill has been removed by the admin.`,
+      referenceId: paymentId,
+      referenceType: "payment",
+    });
+  }
 
   await createActivityLog({
     userId: adminId,
@@ -265,4 +307,7 @@ export const deletePayment = async (paymentId, adminId) => {
     referenceId: paymentId,
     referenceType: "payment",
   });
+
+  // Return tenant ID so the controller can push a real-time socket event
+  return { tenantId: tenant?.ID ?? null };
 };

--- a/backend/services/caretaker/caretakerPaymentService.js
+++ b/backend/services/caretaker/caretakerPaymentService.js
@@ -9,15 +9,17 @@ import { sendSMS } from "../../utils/sms.js";
 import { sms } from "../../utils/smsTemplates.js";
 
 export const getAllPayments = async () => {
-  // Eagerly mark any unpaid payments past their due date as Overdue before returning
   const now = new Date();
   const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+
+  // Mark overdue — skip deleted rows
   await Payment.update(
     { status: "Overdue" },
-    { where: { due_date: { [Op.lt]: todayStr }, status: "Unpaid" } }
+    { where: { due_date: { [Op.lt]: todayStr }, status: "Unpaid", is_deleted: { [Op.or]: [false, null] } } }
   );
 
   return await Payment.findAll({
+    where: { is_deleted: { [Op.or]: [false, null] } },
     include: [{
       model: Contract,
       as: "contract",
@@ -38,7 +40,7 @@ export const getAllPayments = async () => {
 
 export const getPendingPayments = async () => {
   return await Payment.findAll({
-    where: { status: "Pending Verification" },
+    where: { status: "Pending Verification", is_deleted: { [Op.or]: [false, null] } },
     include: [{
       model: Contract,
       as: "contract",

--- a/backend/services/userPaymentService.js
+++ b/backend/services/userPaymentService.js
@@ -2,6 +2,7 @@ import Payment from "../models/payment.js";
 import Contract from "../models/contract.js";
 import User from "../models/user.js";
 import Unit from "../models/unit.js";
+import { Op } from "sequelize";
 import { createNotification } from "../services/notificationService.js";
 import { createActivityLog } from "../services/activityLogService.js";
 import { sendSMSBulk } from "../utils/sms.js";
@@ -9,6 +10,7 @@ import { sms } from "../utils/smsTemplates.js";
 
 export const getMyPayments = async (userId) => {
   return await Payment.findAll({
+    where: { is_deleted: { [Op.or]: [false, null] } },
     include: [{
       model: Contract,
       as: "contract",
@@ -69,6 +71,10 @@ export const uploadPaymentReceipt = async (paymentId, imageUrl, userId, paymentT
   });
 
   if (!payment) throw new Error("Payment not found or access denied");
+
+  if (payment.is_deleted) {
+    throw new Error("This bill has been removed and can no longer be paid.");
+  }
 
   if (payment.status !== "Unpaid" && payment.status !== "Overdue") {
     throw new Error("Receipt already uploaded or payment processed");

--- a/backend/utils/addSoftDeleteColumns.js
+++ b/backend/utils/addSoftDeleteColumns.js
@@ -1,0 +1,43 @@
+import { sequelize } from "../config/database.js";
+import "dotenv/config";
+
+const run = async () => {
+  try {
+    await sequelize.authenticate();
+    console.log("Connected to database.");
+
+    const qi = sequelize.getQueryInterface();
+    const tableDesc = await qi.describeTable("payments");
+
+    if (!tableDesc.is_deleted) {
+      await qi.addColumn("payments", "is_deleted", {
+        type: "TINYINT(1)",
+        allowNull: false,
+        defaultValue: 0,
+        after: "status",
+      });
+      console.log("✓ Added column: is_deleted");
+    } else {
+      console.log("— Column already exists: is_deleted");
+    }
+
+    if (!tableDesc.deleted_at) {
+      await qi.addColumn("payments", "deleted_at", {
+        type: "DATETIME",
+        allowNull: true,
+        after: "is_deleted",
+      });
+      console.log("✓ Added column: deleted_at");
+    } else {
+      console.log("— Column already exists: deleted_at");
+    }
+
+    console.log("\nMigration complete. You can now restart the server.");
+    process.exit(0);
+  } catch (err) {
+    console.error("Migration failed:", err.message);
+    process.exit(1);
+  }
+};
+
+run();

--- a/frontend/src/api/tenantAPI/PaymentAPI.js
+++ b/frontend/src/api/tenantAPI/PaymentAPI.js
@@ -22,3 +22,10 @@ export const uploadReceipt = async (paymentId, formData) => {
   paymentsCacheTime = 0;
   return response.data;
 };
+
+// Call this to force a fresh fetch on the next fetchMyPayments call
+// (used when a socket event signals the admin changed something)
+export const bustPaymentsCache = () => {
+  paymentsCache = null;
+  paymentsCacheTime = 0;
+};

--- a/frontend/src/pages/AdminPage/Dashboard.jsx
+++ b/frontend/src/pages/AdminPage/Dashboard.jsx
@@ -295,7 +295,8 @@ export default function AdminDashboard() {
         />
         <StatCard
           icon={<FaMoneyBillWave size={18} />}
-          label="Total Collected" value={fmt(payDash.totalCollected)}
+          label={`Total Monthly Collected${payDash.currentBillingMonth ? ` — ${new Date(payDash.currentBillingMonth).toLocaleDateString("en-US", { month: "long", year: "numeric" })}` : ""}`}
+          value={fmt(payDash.totalMonthlyCollected ?? 0)}
           color="text-emerald-500" bg="bg-emerald-50"
         />
       </div>

--- a/frontend/src/pages/AdminPage/Payment.jsx
+++ b/frontend/src/pages/AdminPage/Payment.jsx
@@ -306,7 +306,13 @@ export default function AdminPayment() {
 
           {/* STAT CARDS */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
-            <StatCard icon={<FaMoneyBillWave size={18} />} label="Total Collected" value={`₱${Number(dashboard.totalCollected ?? 0).toLocaleString()}`} color="text-emerald-500" bg="bg-emerald-50" />
+            <StatCard
+              icon={<FaMoneyBillWave size={18} />}
+              label={`Total Monthly Collected${dashboard.currentBillingMonth ? ` — ${new Date(dashboard.currentBillingMonth).toLocaleDateString("en-US", { month: "long", year: "numeric" })}` : ""}`}
+              value={`₱${Number(dashboard.totalMonthlyCollected ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2 })}`}
+              color="text-emerald-500"
+              bg="bg-emerald-50"
+            />
             <StatCard icon={<FaClock size={18} />} label="Pending Verification" value={dashboard.pendingVerification ?? 0} color="text-blue-500" bg="bg-blue-50" />
             <StatCard icon={<FaExclamationCircle size={18} />} label="Overdue" value={dashboard.overduePayments ?? 0} color="text-amber-500" bg="bg-amber-50" />
             <StatCard icon={<FaCheckCircle size={18} />} label="Unpaid Bills" value={dashboard.unpaidBills ?? 0} color="text-red-500" bg="bg-red-50" />

--- a/frontend/src/pages/CaretakerPage/Dashboard.jsx
+++ b/frontend/src/pages/CaretakerPage/Dashboard.jsx
@@ -115,7 +115,7 @@ export default function CaretakerDashboard() {
         <div className="w-full flex flex-col gap-4 sm:gap-5 font-sans text-slate-800">
 
             {/* Welcome Banner */}
-            <div className="bg-gradient-to-r from-[#3a0f08] to-[#db6747] rounded-2xl px-6 sm:px-8 py-5 flex items-center justify-between shadow-sm relative overflow-hidden shrink-0">
+            <div className="bg-linear-to-r from-[#3a0f08] to-[#db6747] rounded-2xl px-6 sm:px-8 py-5 flex items-center justify-between shadow-sm relative overflow-hidden shrink-0">
                 <div className="absolute top-0 right-0 w-64 h-64 bg-white/10 rounded-full blur-3xl -translate-y-1/2 translate-x-1/3 pointer-events-none" />
                 <div className="relative z-10">
                     <p className="text-white/70 text-[10px] uppercase tracking-widest font-bold">Welcome back</p>
@@ -158,7 +158,7 @@ export default function CaretakerDashboard() {
                     <SectionHeader icon={<MdApartment size={15} />} title="Unit Occupancy" sub={`Current status · ${unitStats.total} units`} />
 
                     {/* Doughnut */}
-                    <div className="relative flex-1 min-h-[160px] flex items-center justify-center my-4">
+                    <div className="relative flex-1 min-h-40 flex items-center justify-center my-4">
                         {unitStats.total > 0 ? (
                         <Doughnut
                             data={{

--- a/frontend/src/pages/CaretakerPage/PaymentOverview.jsx
+++ b/frontend/src/pages/CaretakerPage/PaymentOverview.jsx
@@ -88,7 +88,13 @@ export default function CaretakerPaymentOverview() {
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
   const paginated = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
-  const totalCollected = rows.filter((r) => r.status === "Paid").reduce((s, r) => s + Number(r.amount ?? 0), 0);
+  const now = new Date();
+  const currentMonthStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  const currentMonthLabel = now.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+
+  const totalMonthlyCollected = rows
+    .filter((r) => r.status === "Paid" && r.billingMonth?.startsWith(currentMonthStr))
+    .reduce((s, r) => s + Number(r.amount ?? 0), 0);
   const pendingCount = rows.filter((r) => r.status === "Pending Verification").length;
   const overdueCount = rows.filter((r) => r.status === "Overdue").length;
   const unpaidCount = rows.filter((r) => r.status === "Unpaid").length;
@@ -181,7 +187,7 @@ export default function CaretakerPaymentOverview() {
 
           {/* STAT CARDS */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
-            <StatCard icon={<FaMoneyBillWave size={18} />} label="Total Collected" value={`₱${totalCollected.toLocaleString()}`} color="text-emerald-500" bg="bg-emerald-50" />
+            <StatCard icon={<FaMoneyBillWave size={18} />} label={`Total Monthly Collected — ${currentMonthLabel}`} value={`₱${totalMonthlyCollected.toLocaleString(undefined, { minimumFractionDigits: 2 })}`} color="text-emerald-500" bg="bg-emerald-50" />
             <StatCard icon={<FaClock size={18} />} label="Pending Verification" value={pendingCount} color="text-blue-500" bg="bg-blue-50" />
             <StatCard icon={<FaExclamationCircle size={18} />} label="Overdue" value={overdueCount} color="text-amber-500" bg="bg-amber-50" />
             <StatCard icon={<FaCheckCircle size={18} />} label="Unpaid Bills" value={unpaidCount} color="text-red-500" bg="bg-red-50" />

--- a/frontend/src/pages/TenantPage/Dashboard.jsx
+++ b/frontend/src/pages/TenantPage/Dashboard.jsx
@@ -13,14 +13,16 @@ import {
   FaCalendarAlt,
   FaFileInvoice,
   FaExternalLinkAlt,
+  FaBan,
 } from "react-icons/fa";
 
 import { fetchTenantProfile } from "../../api/tenantAPI/tenantAuth";
 import { fetchAnnouncements, fetchSingleAnnouncement } from "../../api/tenantAPI/AnnouncementAPI";
-import { fetchMyPayments, uploadReceipt } from "../../api/tenantAPI/PaymentAPI";
+import { fetchMyPayments, uploadReceipt, bustPaymentsCache } from "../../api/tenantAPI/PaymentAPI";
 import { fetchUserContracts } from "../../api/tenantAPI/ContractAPI";
 import ModalPortal from "../../components/ModalPortal";
 import GeneralConfirmationModal from "../../components/GeneralConfirmationModal";
+import { useSocketEvent } from "../../hooks/useSocketEvent";
 
 export default function DashboardCards() {
   const [profile, setProfile] = useState(null);
@@ -53,7 +55,33 @@ export default function DashboardCards() {
   const [utilityBillUrl, setUtilityBillUrl] = useState(null);
 
   useEffect(() => {
-    const loadData = async () => {
+    loadData();
+  }, []);
+
+  // Re-fetch bills immediately when admin deletes or changes a payment
+  useSocketEvent("payment_updated", () => {
+    bustPaymentsCache();
+    loadBills();
+  });
+
+  const loadBills = async () => {
+    try {
+      const payRes = await fetchMyPayments();
+      if (payRes.success && payRes.payments) {
+        const rent = payRes.payments.find(
+          (p) => p.type === "Rent" || p.category === "Rent",
+        );
+        const util = payRes.payments.find(
+          (p) => p.type === "Utilities" || p.category === "Utilities",
+        );
+        setBills({ rent: rent || null, utilities: util || null });
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const loadData = async () => {
       try {
         const profileRes = await fetchTenantProfile();
         setProfile(profileRes.user);
@@ -96,9 +124,7 @@ export default function DashboardCards() {
       } catch (err) {
         console.error(err);
       }
-    };
-    loadData();
-  }, []);
+  };
 
   useEffect(() => {
     const updateCountdown = () => {
@@ -272,7 +298,7 @@ export default function DashboardCards() {
           </div>
 
           {/* RIGHT: Announcements (4 cols) */}
-          <div className="lg:col-span-4 min-h-[300px] lg:h-auto lg:min-h-[320px]">
+          <div className="lg:col-span-4 min-h-[300px] lg:h-auto lg:min-h-80">
             <div className="bg-[#7a2e1a] rounded-2xl sm:rounded-3xl p-4 sm:p-5 md:p-7 text-[#FFEDE1] shadow-xl flex flex-col relative overflow-hidden h-full" style={{ minHeight: "300px" }}>
               <div className="flex items-center justify-between mb-4 sm:mb-5">
                 <h2 className="flex items-center gap-2 font-bold text-sm sm:text-base">
@@ -550,21 +576,28 @@ function StatCard({ icon, label, value, color, bg }) {
 }
 
 function PaymentCard({ title, bill, onPay, utilityBillFile, onViewBill }) {
+  const isDeleted = bill?.is_deleted === true || bill?.is_deleted === 1;
+
   const getStatusStyles = (status) => {
     switch (status) {
       case "Paid":                  return { bg: "#DCFCE7", text: "#22C55E", label: "PAID" };
-      case "Pending Verification":  return { bg: "#FEF3C7", text: "#F59E0B", label: "VERIFYING" }; // Shortened for mobile
+      case "Pending Verification":  return { bg: "#FEF3C7", text: "#F59E0B", label: "VERIFYING" };
       case "Unpaid":                return { bg: "#FEE2E2", text: "#EF4444", label: "UNPAID" };
       case "Overdue":               return { bg: "#FEE2E2", text: "#DC2626", label: "OVERDUE" };
       default:                      return { bg: "#F3F4F6", text: "#6B7280", label: "NO INVOICE" };
     }
   };
 
-  const style = getStatusStyles(bill?.status);
-  const isPaid = bill?.status === "Paid" || bill?.status === "Pending Verification";
+  // Deleted bills always show a grey "DELETED" badge
+  const style = isDeleted
+    ? { bg: "#F1F5F9", text: "#64748B", label: "DELETED" }
+    : getStatusStyles(bill?.status);
+
+  const isPaid = !isDeleted && (bill?.status === "Paid" || bill?.status === "Pending Verification");
 
   return (
-    <div className="bg-white p-5 sm:p-7 rounded-2xl sm:rounded-[2rem] shadow-sm border border-[#F2DED4] flex flex-col justify-between h-full group hover:border-[#f7b094] transition-all">
+    <div className={`bg-white p-5 sm:p-7 rounded-2xl sm:rounded-4xl shadow-sm border flex flex-col justify-between h-full transition-all
+      ${isDeleted ? "border-slate-200 opacity-70" : "border-[#F2DED4] group hover:border-[#f7b094]"}`}>
       <div>
         <div className="flex flex-col sm:flex-row justify-between items-start gap-2 mb-3 sm:mb-5">
           <p className="text-[#330101]/50 text-[9px] sm:text-[10px] font-bold uppercase tracking-widest leading-tight">{title}</p>
@@ -575,16 +608,23 @@ function PaymentCard({ title, bill, onPay, utilityBillFile, onViewBill }) {
         </div>
         <h2 className="text-3xl sm:text-4xl font-black text-[#330101] tracking-tight">
           <span className="text-base sm:text-lg font-medium text-[#330101]/30 mr-1 sm:mr-1.5">₱</span>
-          {bill?.status === "Paid"
+          {isDeleted
             ? "0.00"
-            : bill?.amount
-              ? parseFloat(bill.amount).toLocaleString(undefined, { minimumFractionDigits: 2 })
-              : "0.00"}
+            : bill?.status === "Paid"
+              ? "0.00"
+              : bill?.amount
+                ? parseFloat(bill.amount).toLocaleString(undefined, { minimumFractionDigits: 2 })
+                : "0.00"}
         </h2>
       </div>
 
       <div className="mt-5 sm:mt-7">
-        {!isPaid ? (
+        {isDeleted ? (
+          // Deleted bill — fully disabled, no action possible
+          <div className="w-full flex items-center justify-center gap-2 bg-slate-100 text-slate-400 text-[10px] sm:text-xs font-bold py-3.5 sm:py-4 rounded-xl sm:rounded-2xl border border-dashed border-slate-200 uppercase tracking-widest cursor-not-allowed select-none">
+            <FaBan className="w-3.5 h-3.5 sm:w-4 sm:h-4" /> Bill Removed
+          </div>
+        ) : !isPaid ? (
           <button
             onClick={onPay}
             disabled={!bill}
@@ -598,8 +638,8 @@ function PaymentCard({ title, bill, onPay, utilityBillFile, onViewBill }) {
           </div>
         )}
 
-        {/* View Utility Bill button — only on utilities card, only when a file exists and bill is not paid */}
-        {onViewBill && utilityBillFile && bill?.status !== "Paid" && (
+        {/* View Utility Bill button — only when not deleted, not paid, and file exists */}
+        {!isDeleted && onViewBill && utilityBillFile && bill?.status !== "Paid" && (
           <button
             onClick={onViewBill}
             className="mt-2.5 w-full flex items-center justify-center gap-2 text-[10px] sm:text-xs font-bold py-3 sm:py-3.5 rounded-xl sm:rounded-2xl border border-[#F2DED4] text-[#D96648] hover:bg-[#FDF2ED] transition-all uppercase tracking-widest active:scale-[0.98]"

--- a/frontend/src/pages/TenantPage/PaymentHistory.jsx
+++ b/frontend/src/pages/TenantPage/PaymentHistory.jsx
@@ -2,16 +2,18 @@ import { useState, useEffect } from "react";
 import {
   FaReceipt, FaSearch, FaCloudUploadAlt, FaEye,
   FaTimes, FaWallet, FaMobileAlt, FaCheckCircle,
-  FaCalendarAlt,
+  FaCalendarAlt, FaBan,
 } from "react-icons/fa";
-import { fetchMyPayments, uploadReceipt } from "../../api/tenantAPI/PaymentAPI";
+import { fetchMyPayments, uploadReceipt, bustPaymentsCache } from "../../api/tenantAPI/PaymentAPI";
 import GeneralConfirmationModal from "../../components/GeneralConfirmationModal";
+import { useSocketEvent } from "../../hooks/useSocketEvent";
 
 const STATUS_STYLES = {
   "Paid": { bg: "#DCFCE7", text: "#16A34A", dot: "bg-emerald-400" },
   "Pending Verification": { bg: "#FEF3C7", text: "#D97706", dot: "bg-amber-400" },
   "Unpaid": { bg: "#FEE2E2", text: "#DC2626", dot: "bg-red-400" },
   "Overdue": { bg: "#FEE2E2", text: "#B91C1C", dot: "bg-red-600" },
+  "Deleted": { bg: "#F1F5F9", text: "#64748B", dot: "bg-slate-400" },
 };
 
 const fmt = (d) =>
@@ -42,6 +44,12 @@ export default function PaymenthisCards() {
 
   useEffect(() => { load(); }, []);
 
+  // Re-fetch immediately when admin makes any payment change (including deletion)
+  useSocketEvent("payment_updated", () => {
+    bustPaymentsCache();
+    load(true);
+  });
+
   const load = async (silent = false) => {
     try {
       if (!silent) setLoading(true);
@@ -67,7 +75,11 @@ export default function PaymenthisCards() {
     return matchSearch && matchStatus && matchCategory;
   });
 
-  const canUpload = (p) => p.status === "Unpaid" || p.status === "Overdue";
+  const canUpload = (p) => !p.is_deleted && (p.status === "Unpaid" || p.status === "Overdue");
+
+  // Normalize display: deleted bills show ₱0.00 and a "Deleted" status label
+  const displayStatus = (p) => p.is_deleted ? "Deleted" : p.status;
+  const displayAmount = (p) => p.is_deleted ? "₱0.00" : fmtAmount(p.amount);
 
   const openUpload = (payment) => {
     setUploadModal({ payment });
@@ -195,20 +207,20 @@ export default function PaymenthisCards() {
                   </thead>
                   <tbody className="divide-y divide-[#F2DED4]">
                     {filtered.map((p) => {
-                      const st = STATUS_STYLES[p.status] || STATUS_STYLES["Unpaid"];
+                      const st = STATUS_STYLES[displayStatus(p)] || STATUS_STYLES["Unpaid"];
                       return (
-                        <tr key={p.ID || p.id} className="hover:bg-[#FFF9F6] transition-colors">
+                        <tr key={p.ID || p.id} className={`hover:bg-[#FFF9F6] transition-colors ${p.is_deleted ? "opacity-60" : ""}`}>
                           <td className="py-4 px-6 font-bold text-sm text-[#330101]">{p.category}</td>
                           <td className="py-4 px-6 text-sm text-[#330101]/70">{fmt(p.billing_month)}</td>
                           <td className="py-4 px-6 text-sm text-[#330101]/70">{fmt(p.due_date)}</td>
-                          <td className="py-4 px-6 font-black text-sm text-[#330101]">{fmtAmount(p.amount)}</td>
+                          <td className="py-4 px-6 font-black text-sm text-[#330101]">{displayAmount(p)}</td>
                           <td className="py-4 px-6 text-sm text-[#330101]/70">{fmt(p.payment_date)}</td>
                           <td className="py-4 px-6 text-sm text-[#330101]/60">{p.paymentType || "—"}</td>
                           <td className="py-4 px-6">
                             <span className="inline-flex items-center gap-1.5 text-[10px] font-black px-3 py-1.5 rounded-full uppercase tracking-widest"
                               style={{ backgroundColor: st.bg, color: st.text }}>
                               <span className={`w-1.5 h-1.5 rounded-full ${st.dot}`} />
-                              {p.status}
+                              {displayStatus(p)}
                             </span>
                           </td>
                           <td className="py-4 px-6">
@@ -223,6 +235,11 @@ export default function PaymenthisCards() {
                                   <FaCloudUploadAlt size={13} />
                                 </button>
                               )}
+                              {p.is_deleted && (
+                                <span title="This bill has been removed" className="p-2 rounded-xl bg-slate-100 text-slate-400 cursor-not-allowed">
+                                  <FaBan size={13} />
+                                </span>
+                              )}
                             </div>
                           </td>
                         </tr>
@@ -235,9 +252,9 @@ export default function PaymenthisCards() {
               {/* Mobile cards */}
               <div className="sm:hidden divide-y divide-[#F2DED4]">
                 {filtered.map((p) => {
-                  const st = STATUS_STYLES[p.status] || STATUS_STYLES["Unpaid"];
+                  const st = STATUS_STYLES[displayStatus(p)] || STATUS_STYLES["Unpaid"];
                   return (
-                    <div key={p.ID || p.id} className="p-5 space-y-3">
+                    <div key={p.ID || p.id} className={`p-5 space-y-3 ${p.is_deleted ? "opacity-60" : ""}`}>
                       <div className="flex items-start justify-between gap-3">
                         <div>
                           <p className="font-black text-sm text-[#330101]">{p.category}</p>
@@ -246,13 +263,13 @@ export default function PaymenthisCards() {
                         <span className="inline-flex items-center gap-1.5 text-[10px] font-black px-3 py-1.5 rounded-full uppercase tracking-widest shrink-0"
                           style={{ backgroundColor: st.bg, color: st.text }}>
                           <span className={`w-1.5 h-1.5 rounded-full ${st.dot}`} />
-                          {p.status}
+                          {displayStatus(p)}
                         </span>
                       </div>
                       <div className="flex items-center justify-between">
                         <div>
                           <p className="text-[10px] text-[#330101]/40 uppercase tracking-widest">Amount</p>
-                          <p className="font-black text-base text-[#330101]">{fmtAmount(p.amount)}</p>
+                          <p className="font-black text-base text-[#330101]">{displayAmount(p)}</p>
                         </div>
                         <div className="text-right">
                           <p className="text-[10px] text-[#330101]/40 uppercase tracking-widest">Due</p>
@@ -269,6 +286,11 @@ export default function PaymenthisCards() {
                             className="flex-1 flex items-center justify-center gap-2 py-2.5 rounded-xl bg-[#5c1f10] text-white text-xs font-bold uppercase tracking-widest">
                             <FaCloudUploadAlt size={12} /> Upload
                           </button>
+                        )}
+                        {p.is_deleted && (
+                          <div className="flex-1 flex items-center justify-center gap-2 py-2.5 rounded-xl bg-slate-100 text-slate-400 text-xs font-bold uppercase tracking-widest cursor-not-allowed">
+                            <FaBan size={12} /> Removed
+                          </div>
                         )}
                       </div>
                     </div>
@@ -305,8 +327,8 @@ export default function PaymenthisCards() {
                   ["Category", detailModal.category],
                   ["Billing Month", fmt(detailModal.billing_month)],
                   ["Due Date", fmt(detailModal.due_date)],
-                  ["Amount", fmtAmount(detailModal.amount)],
-                  ["Status", detailModal.status],
+                  ["Amount", displayAmount(detailModal)],
+                  ["Status", displayStatus(detailModal)],
                   ["Payment Date", fmt(detailModal.payment_date)],
                   ["Method", detailModal.paymentType || "—"],
                   ["Reference #", detailModal.paymentType === "GCash" ? (detailModal.referenceNumber || "—") : "—"],


### PR DESCRIPTION
- Add is_deleted and deleted_at columns to payments table (soft-delete migration)
- Switch admin delete to hard delete so re-creation of same bill is allowed
- Exclude deleted bills from all payment queries (admin, caretaker, tenant)
- Fix duplicate check to ignore deleted rows using Op.or [false, null]
- Fix sequelize.sync alter:true FK conflict on contract_tenants table
- Push real-time socket event to tenant on bill deletion
- Send in-app notification to tenant when bill is removed
- Update Total Collected stat to show current billing month only
- Apply monthly collected fix to admin Dashboard, Payment Overview, and caretaker Payment Overview
- Add soft-delete migration script: utils/addSoftDeleteColumns.js
